### PR TITLE
fix: remove undefined behaviors in sync calls

### DIFF
--- a/src/10-warp/warp.cu
+++ b/src/10-warp/warp.cu
@@ -36,13 +36,13 @@ void __global__ test_warp_primitives(void)
     int result = __all_sync(FULL_MASK, tid);
     if (tid == 0) printf("all_sync (FULL_MASK): %d\n", result);
 
-    result = __all_sync(mask1, tid);
+    if (tid != 0) result = __all_sync(mask1, tid);
     if (tid == 1) printf("all_sync     (mask1): %d\n", result);
 
     result = __any_sync(FULL_MASK, tid);
     if (tid == 0) printf("any_sync (FULL_MASK): %d\n", result);
 
-    result = __any_sync(mask2, tid);
+    if (tid == 0) result = __any_sync(mask2, tid);
     if (tid == 0) printf("any_sync     (mask2): %d\n", result);
 
     int value = __shfl_sync(FULL_MASK, tid, 2, WIDTH);


### PR DESCRIPTION
close: #44.

According to the latest CUDA programming guide, the behavior of warp sync functions is undefined if a calling thread is not specified in the mask. Without the necessary conditions check, this example will not produce the expected result. After making the code change in this patch, the code will function as intended.

Tested on 5060 laptop.

ref: https://docs.nvidia.com/cuda/cuda-programming-guide/05-appendices/cpp-language-extensions.html#warp-sync-intrinsic-constraints